### PR TITLE
Make the api_token nullable

### DIFF
--- a/database/migrations/2017_03_04_133429_add_columns_to_user.php
+++ b/database/migrations/2017_03_04_133429_add_columns_to_user.php
@@ -14,7 +14,7 @@ class AddColumnsToUser extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('api_token', 50);
+            $table->string('api_token', 50)->nullable();
             $table->boolean('is_admin')->default(false);
             $table->string('reset_key', 10)->nullable();
         });


### PR DESCRIPTION
This was causing an issue:

```
In Connection.php line 664:
                                                                               
  SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default  
   value NULL (SQL: alter table "users" add column "api_token" varchar not nu  
  ll)                                                                          
                                                                               

In Connection.php line 452:
                                                                               
  SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default  
   value NULL                                                                                                                                             
```

I was using SQLite. It might work with MySQL but generally when you add a column in a migration, you should either make it nullable or set a default value, so that the database engine knows what value to apply for existing records.